### PR TITLE
Add Jest test for TDEE calculator

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "fitnesstest",
+  "version": "1.0.0",
+  "description": "Fitness test project",
+  "devDependencies": {
+    "jest": "^29.6.1"
+  },
+  "scripts": {
+    "test": "jest"
+  }
+}

--- a/tdeeCalculator.js
+++ b/tdeeCalculator.js
@@ -63,4 +63,10 @@ function handleFormSubmission(event) {
 }
 
 // Event listener for form submission
-document.getElementById('calorieForm').addEventListener('submit', handleFormSubmission);
+if (typeof document !== 'undefined') {
+    document.getElementById('calorieForm').addEventListener('submit', handleFormSubmission);
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { calculateTDEE };
+}

--- a/tests/tdeeCalculator.test.js
+++ b/tests/tdeeCalculator.test.js
@@ -1,0 +1,6 @@
+const { calculateTDEE } = require('../tdeeCalculator');
+
+test('calculateTDEE with 180 cm, 70 kg, male, moderatelyActive', () => {
+  const result = calculateTDEE(180, 70, 'male', 'moderatelyActive');
+  expect(result).toBeCloseTo(2642.75, 2);
+});


### PR DESCRIPTION
## Summary
- set up Jest and add test script
- export `calculateTDEE` for Node usage
- test TDEE calculation with known inputs

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68485b44c1b08333813645bd08201fba