### PR TITLE
Fix hex color syntax in HTML

### DIFF
--- a/fitnessPage.html
+++ b/fitnessPage.html
@@ -55,7 +55,7 @@
                 padding: 10px 15px;
                 font-size: 1rem;
                 border: 2px solid black;
-                background-color: ff0000;
+                background-color: #ff0000;
                 color: white;
                 cursor: pointer;
                 transition: background-color 0.3s, color 0.3s;">
@@ -68,7 +68,7 @@
                 padding: 10px 15px;
                 font-size: 1rem;
                 border: 2px solid black;
-                background-color: ff0000;
+                background-color: #ff0000;
                 color: white;
                 cursor: pointer;
                 transition: background-color 0.3s, color 0.3s;">

--- a/nutrition.html
+++ b/nutrition.html
@@ -62,7 +62,7 @@
                 padding: 10px 15px;
                 font-size: 1rem;
                 border: 2px solid black;
-                background-color: ff0000;
+                background-color: #ff0000;
                 color: white;
                 cursor: pointer;
                 transition: background-color 0.3s, color 0.3s;" >
@@ -75,7 +75,7 @@
                 padding: 10px 15px;
                 font-size: 1rem;
                 border: 2px solid black;
-                background-color:ff0000;
+                background-color: #ff0000;
                 color: white;
                 cursor: pointer;
                 transition: background-color 0.3s, color 0.3s;">
@@ -276,7 +276,7 @@
             padding: 10px;
             font-size: 1rem;
             border: 2px solid black;
-            background-color:ff0000;
+            background-color: #ff0000;
             color: white;
             cursor: pointer;
             transition: background-color 0.3s, color 0.3s;


### PR DESCRIPTION
## Summary
- fix background color hex syntax in the HTML files

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68485b42c4e48333b22d200df5abf5a0